### PR TITLE
close not reused tcp connection

### DIFF
--- a/libstns/client.go
+++ b/libstns/client.go
@@ -129,6 +129,7 @@ func (h *client) Request(path, query string) (*Response, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	defer tr.CloseIdleConnections()
 
 	headers := map[string]string{}
 	for k, v := range resp.Header {


### PR DESCRIPTION
https://github.com/STNS/STNS/issues/122
で報告させていただいた件です。

クライアント側の対策に関しては以下の2点があると思っております。
* A案：毎回IdleConnectionをクローズする(現状TCP keep-aliveは行えていないため)
* B案：Transportを使いまわして、TCP keep-aliveが行えるようにする

A案は現状TCP keep-aliveが行えていないので性能的な劣化の懸念はなく、使い終わったTCPコネクションをクローズしているだけなので機能的なデグレリスクも低そうだと考えています。
B案があるべき姿ですが、改修範囲が大きいためv3に入れてもらうのがよいのかなあという気がしています。

そのため、今回はA案の毎回IdleConnectionをクローズするでPRを作成しています。
`make test` を実行してOKになることは確認しています。他にやるべきことがあれば教えて下さい！