### PR TITLE
FIX #122 Reuse a tls connection

### DIFF
--- a/libstns/client_test.go
+++ b/libstns/client_test.go
@@ -54,10 +54,14 @@ func TestClient_Request(t *testing.T) {
 				fmt.Fprintf(w, tt.responseBody)
 			}))
 			defer ts.Close()
-			h := &client{
-				ApiEndpoint: ts.URL,
-				opt:         tt.opt,
+			h, err := newClient(
+				ts.URL,
+				tt.opt,
+			)
+			if err != nil {
+				t.Error(err)
 			}
+
 			got, err := h.Request(tt.path, tt.query)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Client.Request() error = %v, wantErr %v", err, tt.wantErr)

--- a/libstns/stns_test.go
+++ b/libstns/stns_test.go
@@ -77,12 +77,17 @@ func TestSTNS_ListUser(t *testing.T) {
 			}))
 			defer ts.Close()
 
-			s := &STNS{
-				client: &client{
-					ApiEndpoint: ts.URL,
-					opt:         &Options{},
-				},
+			h, err := newClient(
+				ts.URL,
+				&Options{},
+			)
+			if err != nil {
+				t.Error(err)
 			}
+			s := &STNS{
+				client: h,
+			}
+
 			got, err := s.ListUser()
 			if (err != nil) != tt.wantErr {
 				t.Errorf("STNS.ListUser() error = %v, wantErr %v", err, tt.wantErr)
@@ -151,11 +156,15 @@ func TestSTNS_GetUserByName(t *testing.T) {
 			}))
 			defer ts.Close()
 
+			h, err := newClient(
+				ts.URL,
+				&Options{},
+			)
+			if err != nil {
+				t.Error(err)
+			}
 			s := &STNS{
-				client: &client{
-					ApiEndpoint: ts.URL,
-					opt:         &Options{},
-				},
+				client: h,
 			}
 
 			got, err := s.GetUserByName(tt.args.name)
@@ -226,11 +235,15 @@ func TestSTNS_GetUserByID(t *testing.T) {
 			}))
 			defer ts.Close()
 
+			h, err := newClient(
+				ts.URL,
+				&Options{},
+			)
+			if err != nil {
+				t.Error(err)
+			}
 			s := &STNS{
-				client: &client{
-					ApiEndpoint: ts.URL,
-					opt:         &Options{},
-				},
+				client: h,
 			}
 
 			got, err := s.GetUserByID(tt.args.id)
@@ -310,11 +323,15 @@ func TestSTNS_ListGroup(t *testing.T) {
 			}))
 			defer ts.Close()
 
+			h, err := newClient(
+				ts.URL,
+				&Options{},
+			)
+			if err != nil {
+				t.Error(err)
+			}
 			s := &STNS{
-				client: &client{
-					ApiEndpoint: ts.URL,
-					opt:         &Options{},
-				},
+				client: h,
 			}
 			got, err := s.ListGroup()
 			if (err != nil) != tt.wantErr {
@@ -384,11 +401,15 @@ func TestSTNS_GetGroupByName(t *testing.T) {
 			}))
 			defer ts.Close()
 
+			h, err := newClient(
+				ts.URL,
+				&Options{},
+			)
+			if err != nil {
+				t.Error(err)
+			}
 			s := &STNS{
-				client: &client{
-					ApiEndpoint: ts.URL,
-					opt:         &Options{},
-				},
+				client: h,
 			}
 
 			got, err := s.GetGroupByName(tt.args.name)
@@ -459,11 +480,15 @@ func TestSTNS_GetGroupByID(t *testing.T) {
 			}))
 			defer ts.Close()
 
+			h, err := newClient(
+				ts.URL,
+				&Options{},
+			)
+			if err != nil {
+				t.Error(err)
+			}
 			s := &STNS{
-				client: &client{
-					ApiEndpoint: ts.URL,
-					opt:         &Options{},
-				},
+				client: h,
 			}
 
 			got, err := s.GetGroupByID(tt.args.id)


### PR DESCRIPTION
@hogesako 
TLS コネクションを再利用する実装が容易だったので、そのようにしました。
提示頂いた再現コードで改善を確認しています。
```go
package main

import (
	"time"

	"github.com/STNS/libstns-go/libstns"
)

func main() {
	stns, err := libstns.NewSTNS("http://localhost:1104/v1/", nil)
	if err != nil {
		panic(err)
	}
	for i := 0; i < 10000000; i++ {
		stns.Request("/status", "")
		time.Sleep(time.Millisecond * 100)
	}
}

```

```bash
root@7d8d03ea4285:/go/src/github.com/STNS/STNS# date;netstat -an
Mon Feb  1 01:13:11 UTC 2021
Active Internet connections (servers and established)
Proto Recv-Q Send-Q Local Address           Foreign Address         State
tcp6       0      0 :::1104                 :::*                    LISTEN
tcp6       0      0 172.17.0.2:1104         172.17.0.1:55650        ESTABLISHED
Active UNIX domain sockets (servers and established)
Proto RefCnt Flags       Type       State         I-Node   Path
root@7d8d03ea4285:/go/src/github.com/STNS/STNS# date;netstat -an
Mon Feb  1 01:13:13 UTC 2021
Active Internet connections (servers and established)
Proto Recv-Q Send-Q Local Address           Foreign Address         State
tcp6       0      0 :::1104                 :::*                    LISTEN
tcp6       0      0 172.17.0.2:1104         172.17.0.1:55650        ESTABLISHED
Active UNIX domain sockets (servers and established)
Proto RefCnt Flags       Type       State         I-Node   Path

````


