### PR TITLE
Support UNIX domain socket

### DIFF
--- a/libstns/client.go
+++ b/libstns/client.go
@@ -1,6 +1,7 @@
 package libstns
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
@@ -76,6 +77,18 @@ func newClient(endpoint string, opt *Options) (*client, error) {
 		}
 
 		tr.TLSClientConfig = tc
+	}
+
+	if strings.Index(endpoint, "unix") == 0 {
+		u, err := url.Parse(endpoint)
+		if err != nil {
+			logrus.Errorf("unix schema URL parse error:%s", err.Error())
+			return nil, err
+		}
+		tr.DialContext = func(_ context.Context, _, _ string) (net.Conn, error) {
+			return net.Dial("unix", u.Path)
+		}
+		endpoint = "http://unix"
 	}
 
 	tr.Proxy = http.ProxyFromEnvironment


### PR DESCRIPTION
`libstns.NewSTNS` の `endpoint` 引数で、UNIXドメインソケットを指定する操作に対応しました。

これはcache-stnsdが動いている前提の環境において、cache-stnsdにアクセスするために必要でした。

以下のようにすることでUNIXドメインソケットに対して接続できるようになります。

```go
		endpoint := "unix:///var/run/cache-stnsd.sock"
		client, err = libstns.NewSTNS(endpoint, &libstns.Options{
			RequestTimeout: cfg.RequestTimeout,
			RequestRetry:   cfg.RequestRetry,
		})
```

